### PR TITLE
fix/headings in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,20 +15,20 @@ If your application's encryption key is in the hands of a malicious party, that 
 Hence, it is important to rotatate your APP_KEY in frequent invertals. [`Know More`](https://techsemicolon.github.io/blog/2019/06/10/aws-update-ami-systems-manager-automation/)
 
 
-## How can you use this package : 
+## How can you use this package
 
 When APP_KEY is changed in an existing app, any data in your app which you have encrypted using Crypt facade or encrypt() helper function will no longer be decrypted as the encryption uses the APP_KEY.
 
-So when you run `php artisan key:generate` to have a new key as part of key rotation, you need to first decrypt the old encrypted using old APP_KEY and then re-encrypt using newly generated APP_KEY. 
+So when you run `php artisan key:generate` to have a new key as part of key rotation, you need to first decrypt the old encrypted using old APP_KEY and then re-encrypt using newly generated APP_KEY.
 
 
-## Installation : 
+## Installation
 
 ~~~bash
 composer require techsemicolon/laravel-app-key-rotation
 ~~~
 
-## Usage : 
+## Usage
 
 You can instantiate the `ReEncrypter` class by passing old APP_KEY. For that it is important for you to keep your old APP_KEY safe for reference before you rotate APP_KEY to a new one.
 
@@ -43,11 +43,11 @@ $eeEncrypter = new ReEncrypter($oldAppKey);
 $newEncryptedPayload = $eeEncrypter->encrypt($oldEncryptedPayload);
 ~~~
 
-##Suggestion : 
+## Suggestion
 
 When you update your database by new encrypted payload values, make sure you have another column in which you store the old encrypted payload value as a backup. This is to prevent any data loss during the key rotation.
 
-##Example :
+## Example
 
 Let's imagine we have a column called `bank_account_number` in `users` table which is stored as encrypted string. We have another column in the same table as `old_bank_account_number` to store old encrypted payload as backup.
 
@@ -88,7 +88,7 @@ class EncryptionRotateCommand extends Command
 
     /**
      * Function to re-encrypt when APP_KEY is rotated/changed
-     * 
+     *
      * @param string $oldAppKey
      * @param mixed $value
      */
@@ -119,6 +119,6 @@ class EncryptionRotateCommand extends Command
 
 For more detailes about why and how of laravel APP_KEY rotation, [`click here`](https://techsemicolon.github.io/blog/2019/06/10/aws-update-ami-systems-manager-automation/)
 
-## License : 
+## License
 
 This psckage is open-sourced software licensed under the MIT license


### PR DESCRIPTION
Hi mate,

I was browsing your package and saw that there are two Heading where the markup wasn't displayed (because of a missing space).

I don't know if you want this kind of PRs, but maybe it helps.

I also removed the colon in the headings (because my makrdown validator told me to):
![Bildschirmfoto 2021-02-23 um 14 35 02](https://user-images.githubusercontent.com/10073766/108851541-d61ab580-75e4-11eb-8355-8813022c45c2.png)


Thanks for this package.
Cheers ✌🏼
